### PR TITLE
Add PlanController and CRUD features for plans

### DIFF
--- a/earfest.API/Controllers/PlanController.cs
+++ b/earfest.API/Controllers/PlanController.cs
@@ -1,0 +1,46 @@
+﻿using earfest.API.Base;
+using earfest.API.Features.Categories;
+using earfest.API.Features.Plans;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace earfest.API.Controllers;
+
+public class PlanController : EarfestBaseController
+{
+    public PlanController(IMediator mediator) : base(mediator)
+    {
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var result = await _mediator.Send(new GetPlans.Query());
+        return CreateActionResult(result);
+    }
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetById(string id)
+    {
+        var result = await _mediator.Send(new GetPlanById.Query(id));
+        return CreateActionResult(result);
+    }
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreatePlan.Command command)
+    {
+        var result = await _mediator.Send(command);
+        return CreateActionResult(result);
+    }
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(string id, [FromBody] UpdatePlan.Command command)
+    {
+        var updatedCommand = command with {Id = id};
+        var result = await _mediator.Send(updatedCommand);
+        return CreateActionResult(result);
+    }
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(string id)
+    {
+        var result = await _mediator.Send(new DeletePlan.Command(id));
+        return CreateActionResult(result);
+    }
+}

--- a/earfest.API/Features/Plans/CreatePlan.cs
+++ b/earfest.API/Features/Plans/CreatePlan.cs
@@ -1,0 +1,37 @@
+﻿using earfest.API.Base;
+using earfest.API.Domain.DbContexts;
+using earfest.API.Domain.Entities;
+using earfest.API.Models.Moods;
+using FluentValidation;
+using Mapster;
+using MediatR;
+
+namespace earfest.API.Features.Plans;
+
+public static class CreatePlan
+{
+    public record Command(string Name, string Description, string ImageUrl) : IRequest<AppResult<MoodResponse>>;
+    public class CommandHandler(EarfestDbContext _context) : IRequestHandler<Command, AppResult<MoodResponse>>
+    {
+        public async Task<AppResult<MoodResponse>> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var mood = request.Adapt<Mood>();
+            await _context.Moods.AddAsync(mood);
+            await _context.SaveChangesAsync(cancellationToken);
+            return AppResult<MoodResponse>.Success(mood.Adapt<MoodResponse>(), 201);
+        }
+    }
+
+    public class CommandValidator : AbstractValidator<Command>
+    {
+        public CommandValidator()
+        {
+            RuleFor(x => x.Name)
+                .NotNull()
+                .NotEmpty()
+                .MaximumLength(32);
+            RuleFor(x => x.Description)
+                .MaximumLength(256);
+        }
+    }
+}

--- a/earfest.API/Features/Plans/DeletePlan.cs
+++ b/earfest.API/Features/Plans/DeletePlan.cs
@@ -1,0 +1,32 @@
+﻿using earfest.API.Base;
+using earfest.API.Domain.DbContexts;
+using FluentValidation;
+using MediatR;
+
+namespace earfest.API.Features.Plans;
+
+public static class DeletePlan
+{
+    public record Command(string Id) : IRequest<AppResult<NoContentDto>>;
+    public class CommandHandler(EarfestDbContext _context) : IRequestHandler<Command, AppResult<NoContentDto>>
+    {
+        public async Task<AppResult<NoContentDto>> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var plan = await _context.Plans.FindAsync(request.Id);
+            _context.Plans.Remove(plan);
+            await _context.SaveChangesAsync(cancellationToken);
+            return AppResult<NoContentDto>.Success(204);
+        }
+    }
+
+    public class CommandValidator : AbstractValidator<Command>
+    {
+        public CommandValidator()
+        {
+            RuleFor(x => x.Id)
+                .NotNull()
+                .NotEmpty();
+        }
+    }
+
+}

--- a/earfest.API/Features/Plans/GetPlanById.cs
+++ b/earfest.API/Features/Plans/GetPlanById.cs
@@ -1,0 +1,31 @@
+﻿using earfest.API.Base;
+using earfest.API.Domain.DbContexts;
+using earfest.API.Models.Plans;
+using FluentValidation;
+using Mapster;
+using MediatR;
+
+namespace earfest.API.Features.Plans;
+
+public static class GetPlanById
+{
+    public record Query(string Id) : IRequest<AppResult<PlanResponse>>;
+    public class QueryHandler(EarfestDbContext _context) : IRequestHandler<Query, AppResult<PlanResponse>>
+    {
+        public async Task<AppResult<PlanResponse>> Handle(Query request, CancellationToken cancellationToken)
+        {
+            var mood = await _context.Plans.FindAsync(request.Id);
+            return AppResult<PlanResponse>.Success(mood.Adapt<PlanResponse>(),200);
+        }
+    }
+
+    public class QueryValidator : AbstractValidator<Query>
+    {
+        public QueryValidator()
+        {
+            RuleFor(x => x.Id)
+                .NotNull()
+                .NotEmpty();
+        }
+    }
+}

--- a/earfest.API/Features/Plans/GetPlans.cs
+++ b/earfest.API/Features/Plans/GetPlans.cs
@@ -1,0 +1,24 @@
+﻿using earfest.API.Base;
+using earfest.API.Domain.DbContexts;
+using earfest.API.Models;
+using earfest.API.Models.Plans;
+using Mapster;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace earfest.API.Features.Plans;
+
+public static class GetPlans
+{
+    public record Query : IRequest<AppResult<List<PlanResponse>>>;
+
+    public class QueryHandler(EarfestDbContext _context) : IRequestHandler<Query, AppResult<List<PlanResponse>>>
+    {
+        public async Task<AppResult<List<PlanResponse>>> Handle(Query request, CancellationToken cancellationToken)
+        {
+            var plans = await _context.Plans.ToListAsync();
+            var response = plans.Adapt<List<PlanResponse>>();
+            return AppResult<List<PlanResponse>>.Success(response,200);
+        }
+    }
+}

--- a/earfest.API/Features/Plans/UpdatePlan.cs
+++ b/earfest.API/Features/Plans/UpdatePlan.cs
@@ -1,0 +1,52 @@
+﻿using earfest.API.Base;
+using earfest.API.Domain.DbContexts;
+using earfest.API.Models.Plans;
+using FluentValidation;
+using Mapster;
+using MediatR;
+
+namespace earfest.API.Features.Plans;
+
+public static class UpdatePlan
+{
+    public record Command(string Id,UpdatePlanRequest Model) : IRequest<AppResult<PlanResponse>>;
+    public class CommandHandler(EarfestDbContext _context) : IRequestHandler<Command, AppResult<PlanResponse>>
+    {
+        public async Task<AppResult<PlanResponse>> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var plan = await _context.Plans.FindAsync(request.Id);
+            plan.Name = request.Model.Name;
+            plan.Description = request.Model.Description;
+            plan.Price = request.Model.Price;
+            plan.Duration = request.Model.Duration;
+            plan.IsTrial = request.Model.IsTrial;
+            plan.IsFree = request.Model.IsFree;
+            plan.IsPremium = request.Model.IsPremium;
+
+            await _context.SaveChangesAsync(cancellationToken);
+            return AppResult<PlanResponse>.Success(plan.Adapt<PlanResponse>(), 200);
+        }
+    }
+
+    public class CommandValidator : AbstractValidator<Command>
+    {
+        public CommandValidator()
+        {
+            RuleFor(x => x.Id)
+                .NotNull()
+                .NotEmpty();
+            RuleFor(x => x.Model.Name)
+                .NotNull()
+                .NotEmpty()
+                .MaximumLength(32);
+            RuleFor(x => x.Model.Description)
+                .MaximumLength(256);
+            RuleFor(x => x.Model.Price)
+                .NotNull()
+                .GreaterThanOrEqualTo(0);
+            RuleFor(x => x.Model.Duration)
+                .NotNull()
+                .GreaterThanOrEqualTo(1);
+        }
+    }
+}

--- a/earfest.API/Models/Plans/PlanResponse.cs
+++ b/earfest.API/Models/Plans/PlanResponse.cs
@@ -1,0 +1,12 @@
+﻿namespace earfest.API.Models.Plans;
+
+public class PlanResponse : BaseResponse
+{
+    public string Name { get; set; }
+    public string? Description { get; set; }
+    public decimal Price { get; set; }
+    public int Duration { get; set; }
+    public bool IsTrial { get; set; }
+    public bool IsFree { get; set; }
+    public bool IsPremium { get; set; }
+}

--- a/earfest.API/Models/Plans/UpdatePlanRequest.cs
+++ b/earfest.API/Models/Plans/UpdatePlanRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace earfest.API.Models.Plans;
+
+public record UpdatePlanRequest(string Name, string? Description, decimal Price, int Duration, bool IsTrial, bool IsFree, bool IsPremium);


### PR DESCRIPTION
Introduce PlanController in earfest.API.Controllers namespace, inheriting from EarfestBaseController and using MediatR for handling HTTP requests related to plans. Implement CRUD operations: CreatePlan, DeletePlan, GetPlanById, GetPlans, and UpdatePlan, each with corresponding commands/queries, handlers, and validators. Add PlanResponse class and UpdatePlanRequest record in earfest.API.Models.Plans namespace to represent plan data models.